### PR TITLE
[FE] 메인서비스 max-width 값 지정, 로그인&관리자 로그인 페이지 수정

### DIFF
--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -11,17 +11,16 @@ interface LayoutProps {
 
 function Layout({ children, showBackButton, title }: LayoutProps) {
   return (
-    <div>
+    <Container>
       <Header title={title} showBackButton={showBackButton} />
-      <Main id="main">{children}</Main>
+      <div id="main">{children}</div>
       <Navigation />
-    </div>
+    </Container>
   );
 }
 
-const Main = styled.div`
-  /* max-width: 768px; */
-  width: 390px;
-  margin: 0 auto;
+const Container = styled.div`
+  max-width: 390px;
+  margin-inline: auto;
 `;
 export default Layout;

--- a/frontend/src/pages/Admin/AdminLogin.tsx
+++ b/frontend/src/pages/Admin/AdminLogin.tsx
@@ -22,11 +22,17 @@ function AdminLogin() {
       <Inner>
         <Title>관리자 로그인</Title>
         <LoginForm onSubmit={onSubmit} register={register} errors={errors} />
-        <AuthOptions
-          description="계정을 잊으셨나요?"
-          linkPath=""
-          linkText="계정찾기"
-        />
+        <div
+          onClick={() =>
+            alert('준비 중인 서비스입니다. 서비스 관리자에게 문의하세요')
+          }
+        >
+          <AuthOptions
+            description="계정을 잊으셨나요?"
+            linkPath=""
+            linkText="계정찾기"
+          />
+        </div>
       </Inner>
     </Container>
   );

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -6,6 +6,9 @@ import LoginForm from '@/components/Login/LoginForm';
 import AuthOptions from '@/components/common/AuthOptions';
 import { IUserLogin } from '@/models/user.model';
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Icon from '@/components/common/Icon';
+import { TextLogo } from '@/assets/icons/textLogo';
 
 // 아이디 저장 만료일 (한달)
 const EXPIRATION_MAX_AGE = 30 * 24 * 60 * 60;
@@ -45,7 +48,9 @@ function Login() {
   }, []);
   return (
     <Container>
-      <Title>로그인</Title>
+      <Title to="/">
+        <Icon width={160} height={38} icon={<TextLogo />} fill="#59B05F" />
+      </Title>
       <LoginForm
         checkedRememberEmail={checkedRememberEmail}
         toggleCheckedRememberEmail={toggleCheckedRememberEmail}
@@ -63,13 +68,17 @@ function Login() {
 }
 
 const Container = styled.div`
+  max-width: 390px;
+  margin-inline: auto;
   padding: ${({ theme }) => theme.padding.mainContent};
 `;
 
-const Title = styled.div`
+const Title = styled(Link)`
+  display: flex;
+  justify-content: center;
   padding-top: 140px;
-  margin-bottom: 120px;
-  text-align: center;
+  margin-bottom: 100px;
+  margin-inline: auto;
   color: ${({ theme }) => theme.color.primary};
   font-size: 42px;
   font-weight: ${({ theme }) => theme.fontWeight.bold};


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 상세 내용

- 레이아웃 컴포넌트 수정 - 메인 서비스(내돈내산) max-width 값 지정 (390px) 및 가운데 정렬 

```jsx
function Layout({ children, showBackButton, title }: LayoutProps) {
  return (
    <Container>
      <Header title={title} showBackButton={showBackButton} />
      <div id="main">{children}</div>
      <Navigation />
    </Container>
  );
}

const Container = styled.div`
  max-width: 390px;
  margin-inline: auto;
`;
```

- 관리자페이지에서 계정찾기 클릭 시 alert창 출력되도록 설정
- 로그인 페이지 width 설정
- 상단바, 네비게이션바를 사용하지 않는 로그인페이지 로고(링크)를 누르면 메인페이지로 이동할 수 있도록 설정

