### PR TITLE
[BE] limit와 offset이 호환되지 않던 문제 수정, 

### DIFF
--- a/backend/src/controllers/reviews.controller.ts
+++ b/backend/src/controllers/reviews.controller.ts
@@ -18,10 +18,11 @@ export interface IReviewQueryParams {
   isVerified?: boolean;
   query?: string;
   liked?: boolean;
-  best?: boolean;
   myReviews?: boolean;
   currentPage?: number;
   limit?: number;
+  sortBy?: string;
+  orderBy?: 'ASC' | 'DESC';
 }
 
 export interface IResponseData {
@@ -50,10 +51,6 @@ const parseQueryParamsToInterface = (
       typeof queryParams.liked === 'string'
         ? queryParams.liked === 'true'
         : undefined,
-    best:
-      typeof queryParams.best === 'string'
-        ? queryParams.best === 'true'
-        : undefined,
     myReviews:
       typeof queryParams.myReviews === 'string'
         ? queryParams.myReviews === 'true'
@@ -69,6 +66,9 @@ const parseQueryParamsToInterface = (
       parseInt(queryParams.limit, 10) <= 100
         ? parseInt(queryParams.limit, 10)
         : undefined,
+    sortBy:
+      typeof queryParams.sortBy === 'string' ? queryParams.sortBy : undefined,
+    orderBy: queryParams.orderBy === 'DESC' ? 'DESC' : 'ASC',
   };
 };
 

--- a/backend/src/models/review.model.ts
+++ b/backend/src/models/review.model.ts
@@ -15,10 +15,11 @@ export const getReviews = async ({
   isVerified,
   query,
   liked,
-  best,
   myReviews,
   currentPage = 1,
   limit,
+  sortBy,
+  orderBy,
   userId,
 }: getReviewParams): Promise<IResponseReview[]> => {
   const queryBuilder = reviewRepository
@@ -82,8 +83,8 @@ export const getReviews = async ({
       .andWhere('like.user_id = :userId', { userId });
   }
 
-  if (best) {
-    queryBuilder.orderBy('likes', 'DESC');
+  if (sortBy && orderBy) {
+    queryBuilder.orderBy(sortBy, orderBy as 'ASC' | 'DESC');
   }
 
   if (myReviews) {
@@ -98,15 +99,11 @@ export const getReviews = async ({
   }
 
   if (currentPage && limit) {
-    queryBuilder.skip((currentPage - 1) * limit);
+    queryBuilder.offset((currentPage - 1) * limit);
   }
 
   if (limit) {
     queryBuilder.limit(limit);
-  }
-
-  if (best) {
-    queryBuilder.offset(3);
   }
 
   const reviews: IResponseReview[] =

--- a/backend/src/models/review.model.ts
+++ b/backend/src/models/review.model.ts
@@ -109,7 +109,8 @@ export const getReviews = async ({
     queryBuilder.offset(3);
   }
 
-  const reviews: IResponseReview[] = await queryBuilder.getRawMany();
+  const reviews: IResponseReview[] =
+    await queryBuilder.getRawMany<IResponseReview>();
 
   return reviews;
 };

--- a/backend/src/models/review.model.ts
+++ b/backend/src/models/review.model.ts
@@ -51,8 +51,10 @@ export const getReviews = async ({
         .select('COUNT(like.id)', 'likes')
         .from(Like, 'like')
         .where('like.review_id = reviews.id');
-    }, 'likes')
-    .addSelect((subQuery) => {
+    }, 'likes');
+
+  if (userId) {
+    queryBuilder.addSelect((subQuery) => {
       return subQuery
         .select('COUNT(`like`.`id`) > 0', 'isLiked')
         .from(Like, 'like')
@@ -60,6 +62,7 @@ export const getReviews = async ({
           userId,
         });
     }, 'isLiked');
+  }
 
   if (categoryId) {
     queryBuilder.andWhere('reviews.category_id = :categoryId', {
@@ -80,7 +83,7 @@ export const getReviews = async ({
   }
 
   if (best) {
-    queryBuilder.orderBy('likes', 'DESC').take(3);
+    queryBuilder.orderBy('likes', 'DESC');
   }
 
   if (myReviews) {
@@ -94,13 +97,18 @@ export const getReviews = async ({
     );
   }
 
-  if (limit) {
-    queryBuilder.take(limit);
-  }
-
   if (currentPage && limit) {
     queryBuilder.skip((currentPage - 1) * limit);
   }
+
+  if (limit) {
+    queryBuilder.limit(limit);
+  }
+
+  if (best) {
+    queryBuilder.offset(3);
+  }
+
   const reviews: IResponseReview[] = await queryBuilder.getRawMany();
 
   return reviews;

--- a/backend/src/services/review.service.ts
+++ b/backend/src/services/review.service.ts
@@ -46,10 +46,11 @@ export const getReviewList = async ({
   isVerified,
   query,
   liked,
-  best,
   myReviews,
   currentPage,
   limit,
+  sortBy,
+  orderBy,
   userId,
 }: getReviewParams): Promise<IResponseReview[]> => {
   let reviews = await getReviews({
@@ -57,10 +58,11 @@ export const getReviewList = async ({
     isVerified,
     query,
     liked,
-    best,
     myReviews,
     currentPage,
     limit,
+    sortBy,
+    orderBy,
     userId,
   });
 


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 상세 내용
typeorm에서 limit와 offset을 나타내는  take, skip이  쿼리를 직접 보내는 getRawMany와 호환되지 않아 수정했습니다.
특정 컬럼에 따라 정렬하는 sortBy, 오름차순인지 내림차순인지 정하는 orderBy를 쿼리 파라미터로 추가하고, 이에 따라 필요없어진 best 파라미터를 api에서 제거했습니다